### PR TITLE
Different hash implementation

### DIFF
--- a/src/swupd/files.go
+++ b/src/swupd/files.go
@@ -39,7 +39,7 @@ const (
 // File represents an entry in a manifest
 type File struct {
 	Name    string
-	Hash    int
+	Hash    hashval
 	Version uint32
 
 	// flags

--- a/src/swupd/hash.go
+++ b/src/swupd/hash.go
@@ -1,17 +1,23 @@
 package swupd
 
+type hashval int
+
 // Hashes is a global map of indices to hashes
 var Hashes = []*string{}
+var invHash = make(map[string]hashval)
 
 // internHash adds only new hashes to the Hashes slice and returns the index at
 // which they are located
-func internHash(hash string) int {
-	for idx, val := range Hashes {
-		if *val == hash {
-			return idx
-		}
+func internHash(hash string) hashval {
+	if key, ok := invHash[hash]; ok {
+		return key
 	}
-
 	Hashes = append(Hashes, &hash)
-	return len(Hashes) - 1
+	key := hashval(len(Hashes) - 1)
+	invHash[hash] = key
+	return key
+}
+
+func (h hashval) String() string {
+	return *Hashes[int(h)]
 }

--- a/src/swupd/hash_test.go
+++ b/src/swupd/hash_test.go
@@ -1,13 +1,16 @@
 package swupd
 
-import "testing"
+import (
+	"fmt"
+	"testing"
+)
 
 func TestInternHash(t *testing.T) {
 	// reset Hashes so we get the expected indices
 	Hashes = []*string{}
 	testCases := []struct {
 		hash     string
-		expected int
+		expected hashval
 	}{
 		{"9bcc1718757db298fb656ae6e2ee143dde746f49fbf6805db7683cb574c36728", 0},
 		{"33ccead640727d66c62be03e089a3ca3f4ef7c374a3eeab79764f9509075b0d8", 1},
@@ -25,5 +28,24 @@ func TestInternHash(t *testing.T) {
 				t.Errorf("interned hash index %v did not match expected %v", idx, tc.expected)
 			}
 		})
+	}
+}
+
+func TestHashPrinting(t *testing.T) {
+	s := "0000000000000000000000000000000000000000000000000000000000000001"
+	v := internHash(s)
+	sout := fmt.Sprintf("%v", v)
+	if sout != s {
+		t.Errorf("in and out of hashtable do not match\n\t%v\n\t%v", sout, s)
+	}
+}
+
+func TestHashPrinting2(t *testing.T) {
+	s := []byte("0000000000000000000000000000000000000000000000000000000000000001")
+	v := internHash(string(s))
+	s[0] = '1'
+	sout := fmt.Sprintf("%v", v)
+	if sout == string(s) {
+		t.Errorf("in and out of hashtable do not match\n\t%v\n\t%v", sout, s)
 	}
 }


### PR DESCRIPTION
The point of using a map (hash table, associative array) to hold the
SHA values is to improve speed. Having an O(n^2) constructor is fine
for a test case of half a dozen unique values, but sucks if we have
half a million.

Also added a String method to allow values to be printed.

Signed-off-by: Icarus Sparry <icarus.w.sparry@intel.com>