### PR TITLE
Support for reasonable 0 value for hashval

### DIFF
--- a/src/swupd/files.go
+++ b/src/swupd/files.go
@@ -180,6 +180,10 @@ func (f *File) setHash(hash string) error {
 	return nil
 }
 
+func (f *File) setHashZero() {
+	f.Hash = 0
+}
+
 func (f *File) getHashString() string {
 	return *Hashes[f.Hash]
 }

--- a/src/swupd/hash.go
+++ b/src/swupd/hash.go
@@ -2,9 +2,11 @@ package swupd
 
 type hashval int
 
+const AllZeroHash = "0000000000000000000000000000000000000000000000000000000000000000"
+
 // Hashes is a global map of indices to hashes
-var Hashes = []*string{}
-var invHash = make(map[string]hashval)
+var Hashes = []*string{&AllZeroHash}
+var invHash = map[string]hashval{AllZeroHash: 0}
 
 // internHash adds only new hashes to the Hashes slice and returns the index at
 // which they are located

--- a/src/swupd/hash_test.go
+++ b/src/swupd/hash_test.go
@@ -5,21 +5,27 @@ import (
 	"testing"
 )
 
+func resetHash() {
+	Hashes = []*string{&allzero}
+	invHash = map[string]hashval{allzero: 0}
+}
+
 func TestInternHash(t *testing.T) {
 	// reset Hashes so we get the expected indices
-	Hashes = []*string{}
+	resetHash()
 	testCases := []struct {
 		hash     string
 		expected hashval
 	}{
-		{"9bcc1718757db298fb656ae6e2ee143dde746f49fbf6805db7683cb574c36728", 0},
-		{"33ccead640727d66c62be03e089a3ca3f4ef7c374a3eeab79764f9509075b0d8", 1},
-		{"33ccead640727d66c62be03e089a3ca3f4ef7c374a3eeab79764f9509075b0d8", 1},
-		{"b26f85ffaf3595ecd9a8b1e0c894f1b9e6e3ed0e8c3f28bcde3d66e63bfedd4d", 2},
-		{"a49e68b3e2230855586e9ffd1b2962a2282411a488b80e3bd65851f068394c0a", 3},
-		{"a49e68b3e2230855586e9ffd1b2962a2282411a488b80e3bd65851f068394c0a", 3},
-		{"a49e68b3e2230855586e9ffd1b2962a2282411a488b80e3bd65851f068394c0a", 3},
-		{"864f78102661c05b61cafcb59785349fd2fb7a956ec00a77198fe5bc2432de76", 4},
+		{"9bcc1718757db298fb656ae6e2ee143dde746f49fbf6805db7683cb574c36728", 1},
+		{"33ccead640727d66c62be03e089a3ca3f4ef7c374a3eeab79764f9509075b0d8", 2},
+		{"33ccead640727d66c62be03e089a3ca3f4ef7c374a3eeab79764f9509075b0d8", 2},
+		{"b26f85ffaf3595ecd9a8b1e0c894f1b9e6e3ed0e8c3f28bcde3d66e63bfedd4d", 3},
+		{"a49e68b3e2230855586e9ffd1b2962a2282411a488b80e3bd65851f068394c0a", 4},
+		{"a49e68b3e2230855586e9ffd1b2962a2282411a488b80e3bd65851f068394c0a", 4},
+		{"a49e68b3e2230855586e9ffd1b2962a2282411a488b80e3bd65851f068394c0a", 4},
+		{"0000000000000000000000000000000000000000000000000000000000000000", 0},
+		{"864f78102661c05b61cafcb59785349fd2fb7a956ec00a77198fe5bc2432de76", 5},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Added support for the 0 value of hashval to map to the
0000000000000000000000000000000000000000000000000000000000000000
string. Updated tests. Added resetHash function to testing to enforce
this. Added setHashZero method for file to set this zero hash.

Signed-off-by: Icarus Sparry <icarus.w.sparry@intel.com>