### PR TITLE
Support more compressors for fullfiles (without the dependencies)

### DIFF
--- a/swupd/external.go
+++ b/swupd/external.go
@@ -1,0 +1,74 @@
+package swupd
+
+import (
+	"io"
+	"os/exec"
+)
+
+type externalWriter struct {
+	cmd   *exec.Cmd
+	input io.WriteCloser
+}
+
+// newExternalWriter creates a Writer that will filter the contents in the
+// external program and then write to w.
+func newExternalWriter(w io.Writer, program string, args ...string) (*externalWriter, error) {
+	cmd := exec.Command(program, args...)
+	input, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, err
+	}
+	cmd.Stdout = w
+	err = cmd.Start()
+	if err != nil {
+		input.Close()
+		return nil, err
+	}
+	return &externalWriter{cmd, input}, nil
+}
+
+func (ew *externalWriter) Write(p []byte) (int, error) {
+	return ew.input.Write(p)
+}
+
+func (ew *externalWriter) Close() error {
+	err := ew.input.Close()
+	if err != nil {
+		return err
+	}
+	return ew.cmd.Wait()
+}
+
+type externalReader struct {
+	cmd    *exec.Cmd
+	output io.ReadCloser
+}
+
+// newExternalReader creates a Reader that will filter the contents of r in the
+// external program before returning it.
+func newExternalReader(r io.Reader, program string, args ...string) (*externalReader, error) {
+	cmd := exec.Command(program, args...)
+	cmd.Stdin = r
+	output, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, err
+	}
+	err = cmd.Start()
+	if err != nil {
+		output.Close()
+		return nil, err
+	}
+	return &externalReader{cmd, output}, nil
+}
+
+func (er *externalReader) Read(p []byte) (int, error) {
+	return er.output.Read(p)
+}
+
+func (er *externalReader) Close() error {
+	err := er.output.Close()
+	if err != nil {
+		return err
+	}
+	return er.cmd.Wait()
+}

--- a/swupd/external_test.go
+++ b/swupd/external_test.go
@@ -1,0 +1,73 @@
+package swupd
+
+import (
+	"bytes"
+	"io/ioutil"
+	"os/exec"
+	"strings"
+	"testing"
+)
+
+func TestExternalWriter(t *testing.T) {
+	tr, err := exec.LookPath("tr")
+	if err != nil {
+		if err == exec.ErrNotFound {
+			t.Skip("couldn't find tr program used for test")
+		}
+		t.Fatal(err)
+	}
+
+	var output bytes.Buffer
+	w, err := newExternalWriter(&output, tr, "e", "a")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	input := "Hello, world!"
+	expected := strings.Replace(input, "e", "a", -1)
+
+	_, err = w.Write([]byte(input))
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = w.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if output.String() != expected {
+		t.Fatalf("got %q, but want %q", output.String(), expected)
+	}
+}
+
+func TestExternalReader(t *testing.T) {
+	tr, err := exec.LookPath("tr")
+	if err != nil {
+		if err == exec.ErrNotFound {
+			t.Skip("couldn't find tr program used for test")
+		}
+		t.Fatal(err)
+	}
+
+	input := "Hello, world!"
+	expected := strings.Replace(input, "e", "a", -1)
+
+	r, err := newExternalReader(strings.NewReader(input), tr, "e", "a")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	output, err := ioutil.ReadAll(r)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if string(output) != expected {
+		t.Fatalf("got %q, but want %q", string(output), expected)
+	}
+
+	err = r.Close()
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/swupd/fullfiles.go
+++ b/swupd/fullfiles.go
@@ -11,8 +11,8 @@ import (
 	"sync"
 )
 
-// DebugFullfiles is a flag to turn on debug statements for fullfile creation
-const DebugFullfiles = false
+// debugFullfiles is a flag to turn on debug statements for fullfile creation.
+const debugFullfiles = false
 
 type compressFunc func(dst io.Writer, src io.Reader) error
 
@@ -180,7 +180,7 @@ func createRegularFullfile(input, name, output string) (err error) {
 		return fmt.Errorf("couldn't find the size of uncompressed fullfile: %s", err)
 	}
 
-	if DebugFullfiles {
+	if debugFullfiles {
 		log.Printf("DEBUG: Creating fullfile %s for regular file %s (%d bytes)", name, input, fi.Size())
 		log.Printf("DEBUG: %s (%d bytes, uncompressed)", filepath.Base(output), uncompressedSize)
 	}
@@ -227,9 +227,17 @@ func createRegularFullfile(input, name, output string) (err error) {
 			os.RemoveAll(candidate)
 		}
 
-		if DebugFullfiles {
+		if debugFullfiles {
 			log.Printf("DEBUG: %s (%d bytes)", filepath.Base(candidate), candidateSize)
 		}
+	}
+
+	if debugFullfiles {
+		bestName := "<uncompressed>"
+		if best != "" {
+			bestName = filepath.Ext(best)[1:]
+		}
+		log.Printf("DEBUG: best algorithm was %s", bestName)
 	}
 
 	if best != "" {


### PR DESCRIPTION
- Use external compressors (gzip, bzip2, xz)
- Remove the use of external tar, as we grow more confident in Go's tar implementation.

The supporting types (externalWriter and externalReader) to use external programs as filters are also being used by pack code (will appear in another PR).

This change was motivated by the fact that by default external xz was producing significant smaller output than the xz package.

This patch replaces #13.
