### PR TITLE
swupd: accept Manifests with "contentsize: 0"

### DIFF
--- a/swupd/manifest.go
+++ b/swupd/manifest.go
@@ -142,10 +142,6 @@ func (m *Manifest) CheckHeaderIsValid() error {
 		return errors.New("manifest has a zero file count")
 	}
 
-	if m.Header.ContentSize == 0 {
-		return errors.New("manifest has zero contentsize")
-	}
-
 	if m.Header.TimeStamp.IsZero() {
 		return errors.New("manifest timestamp not set")
 	}

--- a/swupd/manifest_test.go
+++ b/swupd/manifest_test.go
@@ -216,7 +216,6 @@ func TestCheckInvalidManifestHeaders(t *testing.T) {
 		{"version zero", ManifestHeader{10, 0, 90, 553, time.Unix(1000, 0), 100000, nil}},
 		{"no files", ManifestHeader{10, 100, 90, 0, time.Unix(1000, 0), 100000, nil}},
 		{"no timestamp", ManifestHeader{10, 100, 90, 553, zeroTime, 100000, nil}},
-		{"zero contentsize", ManifestHeader{10, 100, 90, 553, time.Unix(1000, 0), 0, nil}},
 		{"version smaller than previous", ManifestHeader{10, 100, 110, 553, time.Unix(1000, 0), 100000, nil}},
 	}
 


### PR DESCRIPTION
Manifest.MoMs currently are produced with "contentsize: 0", e.g.
https://download.clearlinux.org/update/20010/Manifest.MoM.

Signed-off-by: Caio Marcelo de Oliveira Filho <caio.oliveira@intel.com>