### PR TITLE
swupd: create packs with fullfiles

### DIFF
--- a/swupd/cmd/create-pack/main.go
+++ b/swupd/cmd/create-pack/main.go
@@ -1,0 +1,232 @@
+package main
+
+import (
+	"flag"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"path/filepath"
+	"runtime/pprof"
+	"strconv"
+
+	"github.com/clearlinux/mixer-tools/swupd"
+)
+
+func usage() {
+	fmt.Fprintf(os.Stderr, `Create pack files using a swupd state directory
+
+Usage:
+  create-pack [FLAGS] STATEDIR FROM_VERSION TO_VERSION BUNDLE
+
+  create-pack -all [FLAGS] STATEDIR FROM_VERSION TO_VERSION
+
+Flags:
+`)
+	flag.PrintDefaults()
+	os.Exit(2)
+}
+
+func main() {
+	log.SetFlags(0)
+
+	cpuProfile := flag.String("cpuprofile", "", "write CPU profile to a file")
+	outputDir := flag.String("o", "", "output directory, creates temporary if not specified")
+	useChroot := flag.Bool("chroot", false, "use chroot to speed up pack generation")
+	allBundles := flag.Bool("all", false, "create packs for all bundles new in TO version")
+	force := flag.Bool("f", false, "rewrite packs that already exist")
+	flag.Usage = usage
+
+	flag.Parse()
+	if (*allBundles && flag.NArg() != 3) || (!*allBundles && flag.NArg() != 4) {
+		usage()
+	}
+
+	if *cpuProfile != "" {
+		f, err := os.Create(*cpuProfile)
+		if err != nil {
+			log.Fatalf("couldn't create file for CPU profile: %s", err)
+		}
+		err = pprof.StartCPUProfile(f)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer pprof.StopCPUProfile()
+	}
+
+	stateDir := flag.Arg(0)
+
+	fromVersion := flag.Arg(1)
+	toVersion := flag.Arg(2)
+
+	fromVersionUint := parseUint32(fromVersion)
+	toVersionUint := parseUint32(toVersion)
+
+	if fromVersionUint >= toVersionUint {
+		log.Fatalf("couldn't create pack: FROM_VERSION (%d) must be smaller than TO_VERSION (%d)", fromVersionUint, toVersionUint)
+	}
+
+	chrootDir := ""
+	if *useChroot {
+		chrootDir = filepath.Join(stateDir, "image", toVersion, "full")
+		if _, err := os.Stat(chrootDir); err != nil {
+			log.Fatalf("couldn't access the full chroot: %s", err)
+		}
+	}
+
+	if *outputDir == "" {
+		tempDir, err := ioutil.TempDir(".", "packs-")
+		if err != nil {
+			log.Fatalf("couldn't create output directory: %s", err)
+		}
+		*outputDir = tempDir
+	}
+	log.Printf("Output directory: %s", *outputDir)
+
+	// If we are handling a single bundle, its name is taken directly from the command line.
+	if !*allBundles {
+		name := flag.Arg(3)
+		if name == "full" || name == "MoM" || name == "" {
+			log.Fatalf("invalid bundle name %q", name)
+		}
+		bundle := &bundleToPack{
+			name: name,
+			from: fromVersionUint,
+			to:   toVersionUint,
+		}
+		pack(stateDir, chrootDir, *outputDir, bundle, *force)
+		return
+	}
+
+	//
+	// Collect the corresponding bundle versions. Note that the code below will create packs on
+	// different directories, based on the version that each bundle is in the Manifest.MoM for
+	// the specified toVersion.
+	//
+	toDir := filepath.Join(stateDir, "www", toVersion)
+	toMoM, err := swupd.ParseManifestFile(filepath.Join(toDir, "Manifest.MoM"))
+	if err != nil {
+		log.Fatalf("couldn't read MoM of TO_VERSION (%s): %s", toVersion, err)
+	}
+
+	bundles := make(map[string]*bundleToPack, len(toMoM.Files))
+	for _, f := range toMoM.Files {
+		bundles[f.Name] = &bundleToPack{f.Name, 0, f.Version}
+	}
+
+	// If this is not a zero pack, we might be able to skip some bundles.
+	if fromVersionUint > 0 {
+		fromDir := filepath.Join(stateDir, "www", fromVersion)
+		fromMoM, err := swupd.ParseManifestFile(filepath.Join(fromDir, "Manifest.MoM"))
+		if err != nil {
+			log.Fatalf("couldn't read MoM of FROM_VERSION (%s): %s", fromVersion, err)
+		}
+
+		for _, f := range fromMoM.Files {
+			e, ok := bundles[f.Name]
+			if !ok {
+				// Bundle doesn't exist in new version, no pack needed.
+				continue
+			}
+			if e.to == f.Version {
+				// Versions match, so no pack required.
+				delete(bundles, f.Name)
+				continue
+			}
+			if e.to < f.Version {
+				log.Fatalf("invalid bundle versions for bundle %s, check the MoMs", f.Name)
+			}
+			e.from = f.Version
+		}
+	}
+
+	// TODO: Use goroutines.
+	for _, b := range bundles {
+		pack(stateDir, chrootDir, *outputDir, b, *force)
+	}
+}
+
+type bundleToPack struct {
+	name string
+	from uint32
+	to   uint32
+}
+
+func pack(stateDir, chrootDir string, outputDir string, bundle *bundleToPack, force bool) {
+	toDir := filepath.Join(outputDir, "www", fmt.Sprint(bundle.to))
+	err := os.MkdirAll(toDir, 0755)
+	if err != nil {
+		log.Fatal(err)
+	}
+	outputFilename := filepath.Join(toDir, fmt.Sprintf("pack-%s-from-%d.tar", bundle.name, bundle.from))
+
+	// If we are not forcing, skip the packs already on disk.
+	if !force {
+		_, err = os.Stat(outputFilename)
+		if err == nil {
+			fmt.Printf("Pack already exists for %s from %d to %d\n", bundle.name, bundle.from, bundle.to)
+			return
+		}
+		if !os.IsNotExist(err) {
+			log.Fatal(err)
+		}
+	}
+
+	fmt.Printf("Packing %s from %d to %d...\n", bundle.name, bundle.from, bundle.to)
+
+	m, err := swupd.ParseManifestFile(filepath.Join(stateDir, "www", fmt.Sprint(bundle.to), "Manifest."+bundle.name))
+	if err != nil {
+		log.Fatal(err)
+	}
+	m.Name = bundle.name
+
+	//
+	// Create the file and write the pack to it.
+	//
+	output, err := os.Create(outputFilename)
+	if err != nil {
+		log.Fatal(err)
+	}
+	info, err := swupd.WritePack(output, m, bundle.from, filepath.Join(stateDir, "www"), chrootDir)
+	if err != nil {
+		_ = os.RemoveAll(outputFilename)
+		log.Fatal(err)
+	}
+	err = output.Close()
+	if err != nil {
+		_ = os.RemoveAll(outputFilename)
+		log.Fatal(err)
+	}
+
+	//
+	// Output information about the pack produced.
+	//
+	if len(info.Warnings) > 0 {
+		fmt.Println("Warnings during pack:")
+		for _, w := range info.Warnings {
+			fmt.Printf("  %s\n", w)
+		}
+		fmt.Println()
+	}
+	// TODO: Move this to the info structure itself?
+	fullfiles := 0
+	deltas := 0
+	for _, e := range info.Entries {
+		switch e.State {
+		case swupd.PackedFullfile:
+			fullfiles++
+		case swupd.PackedDelta:
+			deltas++
+		}
+	}
+	fmt.Printf("  Fullfiles in pack: %d\n", fullfiles)
+	fmt.Printf("  Deltas in pack: %d\n", deltas)
+}
+
+func parseUint32(s string) uint32 {
+	parsed, err := strconv.ParseUint(s, 10, 32)
+	if err != nil {
+		log.Fatalf("error parsing value %q: %s", s, err)
+	}
+	return uint32(parsed)
+}

--- a/swupd/external.go
+++ b/swupd/external.go
@@ -66,9 +66,5 @@ func (er *externalReader) Read(p []byte) (int, error) {
 }
 
 func (er *externalReader) Close() error {
-	err := er.output.Close()
-	if err != nil {
-		return err
-	}
 	return er.cmd.Wait()
 }

--- a/swupd/packs.go
+++ b/swupd/packs.go
@@ -14,11 +14,332 @@
 
 package swupd
 
-// Pack is an object containing delta files and full files for downloads
-type Pack struct {
-	Bundle        string
-	FromVersion   uint32
-	ToVersion     uint32
-	FullFileCount uint32
-	Manifest      *Manifest
+import (
+	"archive/tar"
+	"bytes"
+	"compress/bzip2"
+	"compress/gzip"
+	"fmt"
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+)
+
+const debugPacks = false
+
+// PackState describes whether and how a file was packed.
+type PackState int
+
+// Files can be not packed, packed as a delta or packed as a fullfile.
+const (
+	NotPacked PackState = iota
+	PackedDelta
+	PackedFullfile
+)
+
+// PackEntry describes a file that was considered to be in a pack.
+type PackEntry struct {
+	File   *File
+	State  PackState
+	Reason string
+}
+
+// PackInfo contains detailed information about a pack written.
+type PackInfo struct {
+	// TODO: Add stats.
+
+	// Entries contains all the files considered for packing and details about its presence in
+	// the pack.
+	Entries []PackEntry
+
+	// Warnings contains the issues found. These are not considered errors since the pack could
+	// finish by working around the issue, e.g. if file not found in chroot, try to get it from
+	// the fullfiles.
+	Warnings []string
+}
+
+// WritePack writes the pack of a given Manifest from a version to the version of the Manifest. The
+// outputDir is used to pick deltas and fullfiles. If not empty, chrootDir is tried first as a fast
+// alternative to decompressing the fullfiles.
+func WritePack(w io.Writer, m *Manifest, fromVersion uint32, outputDir, chrootDir string) (info *PackInfo, err error) {
+	if m.Name == "" {
+		return nil, fmt.Errorf("manifest has no name")
+	}
+	if fromVersion >= m.Header.Version {
+		return nil, fmt.Errorf("fromVersion (%d) smaller than toVersion (%d)", fromVersion, m.Header.Version)
+	}
+
+	if debugPacks {
+		if chrootDir != "" {
+			log.Printf("DEBUG: using chrootDir=%s for packing", chrootDir)
+		} else {
+			log.Printf("DEBUG: not using chrootDir for packing")
+		}
+	}
+
+	info = &PackInfo{
+		Entries: make([]PackEntry, len(m.Files)),
+	}
+
+	xw, err := newExternalWriter(w, "xz")
+	if err != nil {
+		return nil, err
+	}
+	defer func() {
+		cerr := xw.Close()
+		if err == nil && cerr != nil {
+			info = nil
+			err = cerr
+		}
+	}()
+
+	tw := tar.NewWriter(xw)
+	err = tw.WriteHeader(&tar.Header{
+		Name:     "delta/",
+		Mode:     0700,
+		Typeflag: tar.TypeDir,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("write packed failed: %s", err)
+	}
+	err = tw.WriteHeader(&tar.Header{
+		Name:     "staged/",
+		Mode:     0700,
+		Typeflag: tar.TypeDir,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("write packed failed: %s", err)
+	}
+
+	done := make(map[Hashval]bool)
+	for i, f := range m.Files {
+		entry := &info.Entries[i]
+		entry.File = f
+
+		if f.Version <= fromVersion {
+			entry.Reason = "already in from manifest"
+			continue
+		}
+		if done[f.Hash] {
+			entry.Reason = "hash already packed"
+			continue
+		}
+		if f.Status == statusDeleted {
+			entry.Reason = "file deleted"
+			continue
+		}
+		if f.Status == statusGhosted {
+			entry.Reason = "file ghosted"
+			continue
+		}
+
+		done[f.Hash] = true
+
+		// TODO: Pack deltas when available.
+		entry.State = PackedFullfile
+		entry.Reason = "from fullfile"
+		if chrootDir != "" {
+			var fallback bool
+			fallback, err = copyFromChrootFile(tw, chrootDir, f)
+			if (err != nil) && fallback {
+				info.Warnings = append(info.Warnings, err.Error())
+				err = copyFromFullfile(tw, outputDir, f)
+			} else {
+				entry.Reason = "from chroot"
+			}
+		} else {
+			err = copyFromFullfile(tw, outputDir, f)
+		}
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	err = tw.Close()
+	if err != nil {
+		return nil, err
+	}
+	return info, nil
+}
+
+func copyFromChrootFile(tw *tar.Writer, chrootDir string, f *File) (fallback bool, err error) {
+	realname := filepath.Join(chrootDir, f.Name)
+	fi, err := os.Lstat(realname)
+	if err != nil {
+		return true, err
+	}
+	hdr, err := getHeaderFromFileInfo(fi)
+	if err != nil {
+		return true, err
+	}
+	hdr.Name = f.Hash.String()
+
+	// TODO: Also perform this verification for copyFromFullfile?
+
+	switch f.Type {
+	case typeDirectory:
+		if !fi.IsDir() {
+			return true, fmt.Errorf("couldn't use %s for packing: manifest expected a directory but it is not", realname)
+		}
+		hdr.Typeflag = tar.TypeDir
+	case typeLink:
+		if fi.Mode()&os.ModeSymlink == 0 {
+			return true, fmt.Errorf("couldn't use %s for packing: manifest expected a link but it is not", realname)
+		}
+		var link string
+		link, err = os.Readlink(realname)
+		if err != nil {
+			return true, fmt.Errorf("couldn't use %s for packing: %s", realname, err)
+		}
+		hdr.Typeflag = tar.TypeSymlink
+		hdr.Linkname = link
+	case typeFile:
+		if !fi.Mode().IsRegular() {
+			return true, fmt.Errorf("couldn't use %s for packing: manifest expected a regular file but it is not", realname)
+		}
+		hdr.Typeflag = tar.TypeReg
+	default:
+		return true, fmt.Errorf("unsupported file %s in chroot with type %q", f.Name, f.Type)
+	}
+
+	// After we start writing on the tar writer, we can't let the caller fallback to another
+	// option anymore.
+
+	err = tw.WriteHeader(hdr)
+	if err != nil {
+		return false, err
+	}
+
+	if hdr.Typeflag == tar.TypeReg {
+		realfile, err := os.Open(realname)
+		if err != nil {
+			return false, err
+		}
+		_, err = io.Copy(tw, realfile)
+		if err != nil {
+			return false, err
+		}
+		err = realfile.Close()
+		if err != nil {
+			return false, err
+		}
+	}
+	return false, nil
+}
+
+type compressedTarReader struct {
+	*tar.Reader
+	compressionCloser io.Closer
+}
+
+func (ctr *compressedTarReader) Close() error {
+	if ctr.compressionCloser != nil {
+		return ctr.compressionCloser.Close()
+	}
+	return nil
+}
+
+// Compression algorithms have "magic" bytes in the beginning of the file to identify them.
+var (
+	gzipMagic  = []byte{0x1F, 0x8B}
+	xzMagic    = []byte{0xFD, '7', 'z', 'X', 'Z', 0x00}
+	bzip2Magic = []byte{'B', 'Z', 'h'}
+)
+
+// newCompressedTarReader creates a struct compatible with tar.Reader reading from uncompressed or
+// compressed input.
+func newCompressedTarReader(rs io.ReadSeeker) (*compressedTarReader, error) {
+	var h [6]byte
+	_, err := rs.Read(h[:])
+	if err != nil {
+		return nil, err
+	}
+	_, err = rs.Seek(0, io.SeekStart)
+	if err != nil {
+		return nil, err
+	}
+	result := &compressedTarReader{}
+
+	switch {
+	case bytes.HasPrefix(h[:], gzipMagic):
+		gr, err := gzip.NewReader(rs)
+		if err != nil {
+			return nil, fmt.Errorf("couldn't decompress using gzip: %s", err)
+		}
+		result.compressionCloser = gr
+		result.Reader = tar.NewReader(gr)
+	case bytes.HasPrefix(h[:], xzMagic):
+		xr, err := newExternalReader(rs, "unxz")
+		if err != nil {
+			return nil, fmt.Errorf("couldn't decompress using xz: %s", err)
+		}
+		result.compressionCloser = xr
+		result.Reader = tar.NewReader(xr)
+	case bytes.HasPrefix(h[:], bzip2Magic):
+		br := bzip2.NewReader(rs)
+		result.Reader = tar.NewReader(br)
+	default:
+		// Assume uncompressed tar and let it complain if not valid.
+		result.Reader = tar.NewReader(rs)
+	}
+	return result, nil
+}
+
+func copyFromFullfile(tw *tar.Writer, outputDir string, f *File) (err error) {
+	fullfilePath := filepath.Join(outputDir, fmt.Sprintf("%d", f.Version), "files", f.Hash.String()+".tar")
+	defer func() {
+		if err != nil {
+			_ = os.RemoveAll(fullfilePath)
+		}
+	}()
+
+	fullfile, err := os.Open(fullfilePath)
+	if err != nil {
+		return fmt.Errorf("failed to open fullfile for %s in version %d: %s", f.Name, f.Version, err)
+	}
+	defer func() {
+		cerr := fullfile.Close()
+		if err == nil {
+			err = cerr
+		}
+	}()
+
+	fullfileReader, err := newCompressedTarReader(fullfile)
+	if err != nil {
+		return fmt.Errorf("failed to read fullfile %s: %s", fullfilePath, err)
+	}
+	defer func() {
+		cerr := fullfileReader.Close()
+		if err == nil {
+			err = cerr
+		}
+	}()
+
+	hdr, err := fullfileReader.Next()
+	if err != nil {
+		return fmt.Errorf("failed to read fullfile %s: %s", fullfilePath, err)
+	}
+	hdr.Name = "staged/" + hdr.Name
+	// Sanitize Uname and Gname in case the fullfile hasn't for some reason.
+	// TODO: Consider enforcing this as validation and failing.
+	hdr.Uname = ""
+	hdr.Gname = ""
+
+	err = tw.WriteHeader(hdr)
+	if err != nil {
+		return fmt.Errorf("failed reading fullfile %s: %s", fullfilePath, err)
+	}
+	_, err = io.Copy(tw, fullfileReader)
+	if err != nil {
+		return fmt.Errorf("failed while copying fullfile %s: %s", fullfilePath, err)
+	}
+
+	// TODO: Should we really enforce this fullfile validation here?
+	_, err = fullfileReader.Next()
+	if err != io.EOF {
+		return fmt.Errorf("invalid fullfile %s: expected EOF but got %s", fullfilePath, err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
Add a function WritePack, that will take a pair of from/to versions of
a bundle, and produce a single tar with all the needed files to
perform an update of that bundle. For now, we are only packing
fullfiles -- which is functional but leads to larger pack sizes. Once
deltas are avaialble, we can make packs smaller.

The function supports an optional chrootDir argument, that will be
used to read the files directly instead of uncompressing them from the
"files/" directory.

Different from swupd-server, we don't copy the files to an staged
directory and then archive/compress. By taking advantage of Go
archive/tar package, we can create the tar file directly. Because of
this, the speed up from the chrootDir optimization is smaller in the
Go version.

Also add a test program create-pack, that has the equivalent
functionality of pack-maker.sh: it can generate a single pack for a
from/to pair, or all the relevant packs from a from/to pair. In the
second case, it will dig into the MoM to find the actual from/to pairs
for each relevant bundle.

The test program already contain some logic that will later be adopted
by Mixer and/or the swupd package.
    
Signed-off-by: Caio Marcelo de Oliveira Filho <caio.oliveira@intel.com>