### PR TITLE
Make Manifest Parse/Write more idiomatic

### DIFF
--- a/swupd/cmd/create-fullfiles/main.go
+++ b/swupd/cmd/create-fullfiles/main.go
@@ -57,9 +57,7 @@ func main() {
 		log.Fatalf("couldn't access the full manifest: %s", err)
 	}
 
-	// TODO: Make ReadManifestFromFile return the Manifest.
-	m := &swupd.Manifest{}
-	err := m.ReadManifestFromFile(manifestFile)
+	m, err := swupd.ParseManifestFile(manifestFile)
 	if err != nil {
 		log.Fatalf("couldn't read full manifest %s: %s", manifestFile, err)
 	}

--- a/swupd/create_manifests.go
+++ b/swupd/create_manifests.go
@@ -65,14 +65,14 @@ func initBuildDirs(version uint32, groups []string, imageBase string) error {
 func processBundles(ui UpdateInfo, c config) ([]*Manifest, error) {
 	newManifests := []*Manifest{}
 	for _, bundle := range ui.bundles {
-		oldM := &Manifest{}
 		oldMPath := filepath.Join(c.outputDir, fmt.Sprint(ui.lastVersion), "Manifest."+bundle)
-		if err := oldM.ReadManifestFromFile(oldMPath); err != nil {
+		oldM, err := ParseManifestFile(oldMPath)
+		if err != nil {
 			// throw away read manifest if it is invalid
 			if strings.Contains(err.Error(), "invalid manifest") {
 				fmt.Fprintf(os.Stderr, "%s: %s\n", oldM.Name, err)
-				oldM = &Manifest{}
 			}
+			oldM = &Manifest{}
 		}
 
 		newM := &Manifest{
@@ -169,14 +169,14 @@ func CreateManifests(version uint32, minVersion bool, format uint, statedir stri
 		return err
 	}
 
-	oldFullManifest := Manifest{}
 	oldFullManifestPath := filepath.Join(c.outputDir, fmt.Sprint(lastVersion), "Manifest.full")
-	if err = oldFullManifest.ReadManifestFromFile(oldFullManifestPath); err != nil {
+	oldFullManifest, err := ParseManifestFile(oldFullManifestPath)
+	if err != nil {
 		// throw away read manifest if it is invalid
 		if strings.Contains(err.Error(), "invalid manifest") {
 			fmt.Fprintf(os.Stderr, "full: %s\n", err)
-			oldFullManifest = Manifest{}
 		}
+		oldFullManifest = &Manifest{}
 	}
 
 	if oldFullManifest.Header.Format > format {
@@ -194,14 +194,14 @@ func CreateManifests(version uint32, minVersion bool, format uint, statedir stri
 	}
 
 	timeStamp := time.Now()
-	oldMoM := Manifest{Header: ManifestHeader{Version: lastVersion}}
 	oldMoMPath := filepath.Join(c.stateDir, fmt.Sprint(lastVersion), "Manifest.MoM")
-	if err = oldMoM.ReadManifestFromFile(oldMoMPath); err != nil {
+	oldMoM, err := ParseManifestFile(oldMoMPath)
+	if err != nil {
 		// throw away read manifest if it is invalid
 		if strings.Contains(err.Error(), "invalid manifest") {
 			fmt.Fprintf(os.Stderr, "MoM: %s\n", err)
-			oldMoM = Manifest{}
 		}
+		oldMoM = &Manifest{Header: ManifestHeader{Version: lastVersion}}
 	}
 
 	oldFormat := oldMoM.Header.Format

--- a/swupd/manifest_test.go
+++ b/swupd/manifest_test.go
@@ -227,10 +227,11 @@ func TestCheckInvalidManifestHeaders(t *testing.T) {
 	}
 }
 
-func TestReadManifestFromFileGood(t *testing.T) {
+func TestParseManifestFromFileGood(t *testing.T) {
 	path := "testdata/manifest.good"
-	var m Manifest
-	if err := m.ReadManifestFromFile(path); err != nil {
+
+	m, err := ParseManifestFile(path)
+	if err != nil {
 		t.Error(err)
 	}
 
@@ -239,7 +240,7 @@ func TestReadManifestFromFileGood(t *testing.T) {
 	}
 
 	if len(m.Files) == 0 {
-		t.Error("ReadManifestFromFile did not add file entries to the file list")
+		t.Error("ParseManifestFile did not add file entries to the file list")
 	}
 }
 
@@ -253,9 +254,9 @@ func TestInvalidManifests(t *testing.T) {
 	}
 	for _, name := range files {
 		t.Run(path.Base(name), func(t *testing.T) {
-			var m Manifest
-			if err := m.ReadManifestFromFile(name); err == nil {
-				t.Error("ReadManifestFromFile did not raise error for invalid manifest")
+			_, err := ParseManifestFile(name)
+			if err == nil {
+				t.Error("ParseManifestFile did not raise error for invalid manifest")
 			}
 		})
 	}
@@ -264,13 +265,13 @@ func TestInvalidManifests(t *testing.T) {
 func TestWriteManifestFile(t *testing.T) {
 	path := "testdata/manifest.good"
 
-	var m Manifest
-	if err := m.ReadManifestFromFile(path); err != nil {
+	m, err := ParseManifestFile(path)
+	if err != nil {
 		t.Fatal(err)
 	}
 
 	if len(m.Files) == 0 {
-		t.Fatal("ReadManifestFromFile did not add file entried to the file list")
+		t.Fatal("ParseManifestFile did not add file entried to the file list")
 	}
 
 	// do not use a tempfile here, we just need the unique name

--- a/swupd/manifest_test.go
+++ b/swupd/manifest_test.go
@@ -3,7 +3,6 @@ package swupd
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -308,22 +307,13 @@ func TestWriteManifestFile(t *testing.T) {
 	}
 }
 
-func TestWriteManifestFileBadHeader(t *testing.T) {
+func TestWriteManifestWithBadHeader(t *testing.T) {
 	m := Manifest{Header: ManifestHeader{}}
 
-	f, err := ioutil.TempFile("testdata", "manifest.result")
-	if err != nil {
-		t.Fatal("unable to open file for write")
-	}
-	defer os.Remove(f.Name())
-
-	path := f.Name()
-	if err = m.WriteManifestFile(path); err == nil {
-		t.Error("WriteManifestFile did not fail on invalid header")
-	}
-
-	if err = os.Remove(path); err != nil {
-		t.Error("unable to remove file, did it not close properly?")
+	var output bytes.Buffer
+	err := m.WriteManifest(&output)
+	if err == nil {
+		t.Fatal("WriteManifest did not fail on invalid header")
 	}
 }
 


### PR DESCRIPTION
Extract functions that deal with io.Writer and io.Reader, and make the parser function return a new Manifest instead of being a method of an empty manifest. Commit messages have the details.